### PR TITLE
typo: duplicate "is"

### DIFF
--- a/_posts/2020-09-22-rust-2021.md
+++ b/_posts/2020-09-22-rust-2021.md
@@ -42,7 +42,7 @@ While I think a converged vision is an admirable and ambitious goal, it may not 
 
 Many Rust projects these days come with what's basically a marketing pitch: "adopt this codebase, it's awesome." I am starting to see the Druid project in a somewhat different light. I consider its primary mission to be *teaching and learning* the knowledge required to build GUI. To that extent, the community we're building, hosted on [our Zulip instance,][the xi Zulip] is just as important as the code.
 
-The knowledge needed to build GUI has many aspects, and is at all levels. Some of it is at a high level, like the best way to express reactive UI. Some of it is at a low level, like the keyboard event processing. A common thread is that a lot of is is very arcane, not really written down properly anywhere. Fortunately, a lot of it is accessible through reading the code of other open source projects, whether in Rust or in other languages (I've found both Chromium and Gecko to be especially useful).
+The knowledge needed to build GUI has many aspects, and is at all levels. Some of it is at a high level, like the best way to express reactive UI. Some of it is at a low level, like the keyboard event processing. A common thread is that a lot of it is very arcane, not really written down properly anywhere. Fortunately, a lot of it is accessible through reading the code of other open source projects, whether in Rust or in other languages (I've found both Chromium and Gecko to be especially useful).
 
 So I consider this a goal, a success criterion, of the Druid project. If somebody wants to know how to solve a problem in GUI, the Druid codebase should be one of the best places to look for answers.
 


### PR DESCRIPTION
super mega minor typo