### PR TITLE
Fix dead link to resource on cooperative groups

### DIFF
--- a/_posts/2019-05-08-modern-2d.md
+++ b/_posts/2019-05-08-modern-2d.md
@@ -127,7 +127,7 @@ This work has benefitted from discussions with many, though of course the mistak
 [approximate blurred rounded rectangle]: http://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
 [linear sRGB]: https://linebender.gitbook.io/linebender-graphics-wiki/
 [Subpixel rendering]: https://en.wikipedia.org/wiki/Subpixel_rendering
-[cooperative groups]: http://www.irisa.fr/alf/downloads/collange/talks/collange_warp_synchronous_gpu17.pdf
+[cooperative groups]: http://www.irisa.fr/alf/downloads/collange/talks/collange_warp_synchronous_19.pdf
 [piet]: https://github.com/linebender/piet
 [druid]: https://github.com/xi-editor/druid
 [shadertoy]: https://www.shadertoy.com/


### PR DESCRIPTION
The old link was no longer accessible, so I googled for something like that and found a presumably updated version of the mentioned presentation.