### PR TITLE
Add attributes to details blocks

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -8,3 +8,10 @@ img.center {
     margin: auto;
     display: block;
 }
+
+# Based on https://github.com/jekyll/minima/blob/master/_sass/minima/_base.scss
+details {
+  margin: 0;
+  padding: 0;
+  margin-bottom: $spacing-unit / 2;
+}


### PR DESCRIPTION
`<detail>` blocks in the minima theme have no attributes applied; which means they're not aligned with other paragraphs.

This commit adds properties to detail matching those of other block types in minima.

Note that I haven't actually tested this. I have no idea if it works.